### PR TITLE
Iterate over all available containers to setup HOST_IP (scheduler and…

### DIFF
--- a/files/hub/jupyterhub_config.py
+++ b/files/hub/jupyterhub_config.py
@@ -362,13 +362,14 @@ def secret_creation_hook(spawner, pod):
             patches_to_add);
         del api_crd.api_client.default_headers['Content-Type']
 
-    # Add host IP to the pod envvars
-    pod.spec.containers[0].env.append( \
-        client.V1EnvVar("HOST_IP", my_hostname)
-    )
-    pod.spec.containers[0].env.append( \
-        client.V1EnvVar("WORKER_IP", my_worker_hostname)
-    )
+    # Add host IP to the pod envvars (to scheduler and sidecar)
+    for container in range(len(pod.spec.containers)):
+        pod.spec.containers[container].env.append( \
+            client.V1EnvVar("HOST_IP", my_hostname)
+        )
+        pod.spec.containers[container].env.append( \
+            client.V1EnvVar("WORKER_IP", my_worker_hostname)
+        )
 
     # Generate secrets as necessary.
     label = "jhub_user=%s" % euser


### PR DESCRIPTION
… worker)
```
[root@cmsaf kubeinstance]# kubectl logs jupyter-oksana-2eshadura-40cern-2ech dask-worker
/bin/bash: /opt/conda/lib/libtinfo.so.6: no version information available (required by /bin/bash)
distributed.nanny - INFO -         Start Nanny at: 'tls://192.168.246.118:37037'
distributed.worker - INFO -       Start worker at: tls://oksana-2eshadura-40cern-2ech.dask.coffea.casa:8786
distributed.worker - INFO -          Listening to: tls://oksana-2eshadura-40cern-2ech.dask.coffea.casa:8786
distributed.worker - INFO -          dashboard at: oksana-2eshadura-40cern-2ech.dask.coffea.casa:43187
distributed.worker - INFO - Waiting to connect to:       tls://localhost:8786
distributed.worker - INFO - -------------------------------------------------
distributed.worker - INFO -               Threads:                          4
distributed.worker - INFO -                Memory:                    6.44 GB
distributed.worker - INFO -       Local Directory: /home/jovyan/dask-worker-space/dask-worker-space/worker-n2mqz4jf
distributed.worker - INFO - -------------------------------------------------
distributed.worker - WARNING - Mismatched versions found

+-------------+----------------------+----------------------+----------------------+
| Package     | This Worker          | scheduler            | workers              |
+-------------+----------------------+----------------------+----------------------+
| dask        | 2.26.0               | 2.27.0               | 2.26.0               |
| distributed | 2.16.0+127.gc5f84384 | 2.16.0+155.gcd6177fc | 2.16.0+127.gc5f84384 |
+-------------+----------------------+----------------------+----------------------+
distributed.worker - INFO -         Registered to:       tls://localhost:8786
distributed.worker - INFO - -------------------------------------------------
distributed.core - INFO - Starting established connection
```